### PR TITLE
Add ability to destroy tokens by tokenPrefix

### DIFF
--- a/store.go
+++ b/store.go
@@ -9,6 +9,11 @@ type Store interface {
 	// and return nil (not an error).
 	Delete(token string) (err error)
 
+	// DeleteByPattern will delete all keys that match the provided pattern. If the
+	// pattern doesn't match any keys then DeleteByPattern will no-op and return nil
+	// (not an error).
+	DeleteByPattern(pattern string) (err error)
+
 	// Find should return the data for a session token from the session store.
 	// If the session token is not found or is expired, the found return value
 	// should be false (and the err return value should be nil). Similarly, tampered

--- a/stores/boltstore/boltstore.go
+++ b/stores/boltstore/boltstore.go
@@ -2,6 +2,7 @@
 package boltstore
 
 import (
+	"fmt"
 	"log"
 	"time"
 
@@ -96,6 +97,11 @@ func (bs *BoltStore) Delete(token string) error {
 		tokenBytes := []byte(token)
 		return txDelete(tx, tokenBytes)
 	})
+}
+
+// DeleteByPattern removes all tokens that match the pattern from the BoltStore instance
+func (bs *BoltStore) DeleteByPattern(pattern string) error {
+	return fmt.Errorf("Store: Not implemented")
 }
 
 // startCleanup is a helper func to periodically call deleteExpired.

--- a/stores/buntstore/buntstore.go
+++ b/stores/buntstore/buntstore.go
@@ -2,6 +2,7 @@
 package buntstore
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/tidwall/buntdb"
@@ -53,4 +54,9 @@ func (bs *BuntStore) Delete(token string) error {
 		_, err := tx.Delete(token)
 		return err
 	})
+}
+
+// DeleteByPattern removes all tokens that match the pattern from the BuntStore instance
+func (bs *BuntStore) DeleteByPattern(pattern string) error {
+	return fmt.Errorf("Store: Not implemented")
 }

--- a/stores/cookiestore/cookiestore.go
+++ b/stores/cookiestore/cookiestore.go
@@ -82,6 +82,12 @@ func (c *CookieStore) Delete(token string) error {
 	return nil
 }
 
+// DeleteByPattern is a no-op. The function exists only to ensure that a CookieStore instance
+// satisfies the scs.Store interface.
+func (c *CookieStore) DeleteByPattern(pattern string) error {
+	return nil
+}
+
 func encodeToken(key [32]byte, b []byte, expiry time.Time) (string, error) {
 	expiryTimestamp := []byte(strconv.FormatInt(expiry.UnixNano(), 10))
 	if len(expiryTimestamp) != 19 {

--- a/stores/dynamostore/dynamostore.go
+++ b/stores/dynamostore/dynamostore.go
@@ -5,6 +5,7 @@
 package dynamostore
 
 import (
+	"fmt"
 	"strconv"
 	"time"
 
@@ -125,6 +126,11 @@ func (d *DynamoStore) Delete(token string) error {
 
 	_, err := d.DB.DeleteItem(params)
 	return err
+}
+
+// DeleteByPattern removes all tokens that match the pattern from the DynamoStore instance
+func (d *DynamoStore) DeleteByPattern(pattern string) error {
+	return fmt.Errorf("Store: Not implemented")
 }
 
 // Ping checks to exisit session table in DynamoDB.

--- a/stores/memcachedstore/memcachedstore.go
+++ b/stores/memcachedstore/memcachedstore.go
@@ -1,6 +1,7 @@
 package memcachedstore
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/bradfitz/gomemcache/memcache"
@@ -48,6 +49,11 @@ func (m *MemcachedStore) Save(token string, b []byte, expiry time.Time) error {
 // Delete removes a session token and corresponding data from the MemcachedStore instance.
 func (m *MemcachedStore) Delete(token string) error {
 	return m.client.Delete(Prefix + token)
+}
+
+// DeleteByPattern removes all tokens that match the pattern from the MemcachedStore instance
+func (m *MemcachedStore) DeleteByPattern(pattern string) error {
+	return fmt.Errorf("Store: Not implemented")
 }
 
 // createOffset calculates how expiration dates should be stored

--- a/stores/memstore/memstore.go
+++ b/stores/memstore/memstore.go
@@ -15,6 +15,7 @@ package memstore
 
 import (
 	"errors"
+	"strings"
 	"time"
 
 	"github.com/patrickmn/go-cache"
@@ -65,5 +66,15 @@ func (m *MemStore) Save(token string, b []byte, expiry time.Time) error {
 // Delete removes a session token and corresponding data from the MemStore instance.
 func (m *MemStore) Delete(token string) error {
 	m.cache.Delete(token)
+	return nil
+}
+
+// DeleteByPattern removes all tokens that match the pattern from the MemStore instance
+func (m *MemStore) DeleteByPattern(pattern string) error {
+	for key := range m.cache.Items() {
+		if strings.Contains(key, pattern) {
+			m.cache.Delete(key)
+		}
+	}
 	return nil
 }

--- a/stores/memstore/memstore_test.go
+++ b/stores/memstore/memstore_test.go
@@ -124,3 +124,27 @@ func TestDelete(t *testing.T) {
 		t.Fatalf("got %v: expected %v", found, false)
 	}
 }
+
+func TestDeleteByPattern(t *testing.T) {
+	m := New(time.Minute)
+
+	firstToken := "session_token_1"
+	secondToken := "session_token_2"
+	m.cache.Set(firstToken, []byte("encoded_data"), 0)
+	m.cache.Set(secondToken, []byte("encoded_data"), 0)
+
+	err := m.DeleteByPattern("session_token_")
+	if err != nil {
+		t.Fatalf("got %v: expected %v", err, nil)
+	}
+
+	_, found := m.cache.Get(firstToken)
+	if found != false {
+		t.Fatalf("got %v: expected %v", found, false)
+	}
+
+	_, found = m.cache.Get(secondToken)
+	if found != false {
+		t.Fatalf("got %v: expected %v", found, false)
+	}
+}

--- a/stores/mysqlstore/mysqlstore.go
+++ b/stores/mysqlstore/mysqlstore.go
@@ -17,6 +17,7 @@ package mysqlstore
 
 import (
 	"database/sql"
+	"fmt"
 	"log"
 	"strconv"
 	"strings"
@@ -88,6 +89,11 @@ func (m *MySQLStore) Save(token string, b []byte, expiry time.Time) error {
 func (m *MySQLStore) Delete(token string) error {
 	_, err := m.DB.Exec("DELETE FROM sessions WHERE token = ?", token)
 	return err
+}
+
+// DeleteByPattern removes all tokens that match the pattern from the MySQLStore instance
+func (m *MySQLStore) DeleteByPattern(pattern string) error {
+	return fmt.Errorf("Store: Not implemented")
 }
 
 func (m *MySQLStore) startCleanup(interval time.Duration) {

--- a/stores/pgstore/pgstore.go
+++ b/stores/pgstore/pgstore.go
@@ -17,6 +17,7 @@ package pgstore
 
 import (
 	"database/sql"
+	"fmt"
 	"log"
 	"time"
 
@@ -88,6 +89,11 @@ func (p *PGStore) startCleanup(interval time.Duration) {
 			return
 		}
 	}
+}
+
+// DeleteByPattern removes all tokens that match the pattern from the PGStore instance
+func (p *PGStore) DeleteByPattern(pattern string) error {
+	return fmt.Errorf("Store: Not implemented")
 }
 
 // StopCleanup terminates the background cleanup goroutine for the PGStore instance.

--- a/stores/qlstore/ql.go
+++ b/stores/qlstore/ql.go
@@ -17,6 +17,7 @@ package qlstore
 
 import (
 	"database/sql"
+	"fmt"
 	"log"
 	"time"
 
@@ -64,6 +65,11 @@ func (q *QLStore) startCleanup(interval time.Duration) {
 func (q *QLStore) Delete(token string) error {
 	_, err := execTx(q.DB, "DELETE FROM sessions where token=$1", token)
 	return err
+}
+
+// DeleteByPattern removes all tokens that match the pattern from the QLStore instance
+func (q *QLStore) DeleteByPattern(pattern string) error {
+	return fmt.Errorf("Store: Not implemented")
 }
 
 func (q *QLStore) deleteExpired() error {


### PR DESCRIPTION
Adds new method: `DestroyUsingTokenPrefix(..)` which delete all
tokens that match the patter from storage and remove current session
iif the session's token matches the tokenPrefix.

Note: Only redis and memstore is currently supported store for this
function.

Ref https://github.com/dapperlabs/dapper-api/issues/1326