### PR TITLE
Fix an issue with writing session after deleting a session

### DIFF
--- a/session.go
+++ b/session.go
@@ -164,12 +164,14 @@ func (s *Session) write(w http.ResponseWriter) error {
 	}
 
 	// Overwrite any existing cookie header for the session...
+	// It is possible that there are multiple sessions with the same
+	// s.opts.name. This case typically happens when we Delete a session
+	// and then create another session in the same request.
 	var set bool
 	for i, h := range w.Header()["Set-Cookie"] {
 		if strings.HasPrefix(h, fmt.Sprintf("%s=", s.opts.name)) {
 			w.Header()["Set-Cookie"][i] = cookie.String()
 			set = true
-			break
 		}
 	}
 	// Or set a new one if necessary.


### PR DESCRIPTION
The way this works is that Destroy(..) method writes another `Set-Cookie` header so there are now 2 `Set-Cookie` headers with the same name. The 2nd header is the one that destroys the session. 
Browser uses the latest entry so that is fine and Destroy() functions as expected. 

However, if you tried to write another session in the same request the code for `write` would modify the first `Set-Cookie` leaving the 2nd `Set-Cookie` the same which actually still destroys the session. This PR makes sure that both `Set-Cookies` are modified.