### PR TITLE
Fix an issue with missing session keys

### DIFF
--- a/stores/redisstore/redisstore.go
+++ b/stores/redisstore/redisstore.go
@@ -95,7 +95,11 @@ func (r *RedisStore) DeleteByPattern(pattern string) error {
 
 		// fetch itr and keys from the multi-bulk reply
 		itr, _ = redis.Int(arr[0], nil)
-		keys, _ = redis.Strings(arr[1], nil)
+
+		// get all the keys from this round an then append them
+		// to the final list containing keys from all rounds
+		roundKeys, _ := redis.Strings(arr[1], nil)
+		keys = append(keys, roundKeys...)
 
 		// when SCAN returns a 0 when it is complete
 		if itr == 0 {

--- a/stores/redisstore/redisstore.go
+++ b/stores/redisstore/redisstore.go
@@ -96,7 +96,7 @@ func (r *RedisStore) DeleteByPattern(pattern string) error {
 		// fetch itr and keys from the multi-bulk reply
 		itr, _ = redis.Int(arr[0], nil)
 
-		// get all the keys from this round an then append them
+		// get all the keys from this round and append them
 		// to the final list containing keys from all rounds
 		roundKeys, _ := redis.Strings(arr[1], nil)
 		keys = append(keys, roundKeys...)


### PR DESCRIPTION
It looks like we were re-assigning the keys value each round instead of
appending them to the final list. This caused issues once we had a large
number of sessions.